### PR TITLE
fix(userAvatar): allow admin to create avatar for other user and add some fix

### DIFF
--- a/app/back/src/Controller/Api/UserAvatarController.php
+++ b/app/back/src/Controller/Api/UserAvatarController.php
@@ -4,6 +4,7 @@ namespace App\Controller\Api;
 
 use App\Entity\User;
 use App\Entity\UserAvatar;
+use App\Repository\UserRepository;
 use App\Services\FileUploader;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Bundle\SecurityBundle\Security;
@@ -14,12 +15,17 @@ use Symfony\Component\HttpKernel\Exception\ConflictHttpException;
 #[AsController]
 class UserAvatarController extends AbstractController
 {
-    public function __invoke(Request $request, Security $security, FileUploader $fileUploader): UserAvatar
+    public function __invoke(Request $request, Security $security, FileUploader $fileUploader, UserRepository $userRepository): UserAvatar
     {
         /** @var User $user */
         $user = $security->getUser();
 
         $uploadedFile = $fileUploader->uploadFile($request);
+
+        if (in_array('ROLE_ADMIN', $user->getRoles()) && $request->get('userId') !== null) {
+            /** @var User $user */
+            $user = $userRepository->findOneBy(['id' => $request->get('userId')]);
+        }
 
         if ($user->getUserAvatar() instanceof UserAvatar) {
             throw new ConflictHttpException('This user already has an avatar, please delete old one before');

--- a/app/back/src/Entity/Category.php
+++ b/app/back/src/Entity/Category.php
@@ -5,6 +5,7 @@ namespace App\Entity;
 use ApiPlatform\Metadata\ApiResource;
 use ApiPlatform\Metadata\Get;
 use ApiPlatform\Metadata\GetCollection;
+use App\Entity\Traits\IdentifiableTrait;
 use App\Repository\CategoryRepository;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
@@ -16,17 +17,15 @@ use Symfony\Component\Serializer\Annotation\Groups;
     operations: [
         new Get(),
         new GetCollection(),
-    ]
+    ],
+    normalizationContext: ['groups' => ['category:read', 'id']]
 )]
 class Category extends AbstractEntity
 {
-    #[ORM\Id]
-    #[ORM\GeneratedValue]
-    #[ORM\Column]
-    private ?int $id = null;
+    use IdentifiableTrait;
 
     #[ORM\Column(length: 255)]
-    #[Groups(['work:read', 'masterclass_user:read:item', 'composer:read', 'masterclass:read'])]
+    #[Groups(['work:read', 'masterclass_user:read:item', 'composer:read', 'masterclass:read', 'category:read'])]
     private ?string $name = null;
 
     #[ORM\OneToMany(mappedBy: 'category', targetEntity: Work::class)]

--- a/app/back/src/Entity/UserAvatar.php
+++ b/app/back/src/Entity/UserAvatar.php
@@ -36,6 +36,10 @@ use Vich\UploaderBundle\Mapping\Annotation as Vich;
                                         'type' => 'string',
                                         'format' => 'binary',
                                     ],
+                                    'userId' => [
+                                        'type' => 'integer',
+                                        'format' => 'id',
+                                    ],
                                 ],
                             ],
                         ],
@@ -49,7 +53,7 @@ use Vich\UploaderBundle\Mapping\Annotation as Vich;
             security: 'is_granted("USER_AVATAR_DELETE", object)',
         ),
     ],
-    normalizationContext: ['groups' => ['avatar:read', 'timestamp']],
+    normalizationContext: ['groups' => ['avatar:read', 'timestamp', 'id']],
 )]
 #[Vich\Uploadable]
 class UserAvatar extends AbstractEntity
@@ -95,7 +99,7 @@ class UserAvatar extends AbstractEntity
 
     public function getContentUrl(): ?string
     {
-        return 'files/avatar/' . $this->getImagePath();
+        return 'files/avatars/' . $this->getImagePath();
     }
 
     public function getUser(): ?User


### PR DESCRIPTION
| Q  | A |
| --- | --- |
| Type | fix |
| Related Tickets | [PFR-83](https://project-fil-rouge.atlassian.net/browse/PFR-83) |

## What does this PR do?

- add normalization context for `Category`
- fix contentUrl path for userAvatar
- allow admin to create userAvatar for other user


[PFR-83]: https://project-fil-rouge.atlassian.net/browse/PFR-83?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ